### PR TITLE
Add more dev deps

### DIFF
--- a/.ci/Jenkinsfile-integration-test
+++ b/.ci/Jenkinsfile-integration-test
@@ -36,7 +36,7 @@ pipeline {
             steps {
                 dir(env.REPO_NAME) {
                     script {
-                        sh '${WORKSPACE}/env/bin/poetry install --extras "async extension module"'
+                        sh '${WORKSPACE}/env/bin/poetry install --extras "async extension module pytest"'
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Inmanta dev dependencies
+
+This repository create a virtual package that collects and freezes dependencies used to develop inmanta modules and extensions. The default package mainly packages flake8 packages to enfore the inmanta formatting guideliness.
+
+There are a number of optional packages, available in a number of groups:
+
+- modules: All packages required for linting and tests for inmanta modules
+- extension: All packages required for linting and tests of inmanta orchestrator extensions
+- async: Extra pytest packages for running async tests
+- pytest: A curated list of pytest extensions to improve testing and to improve pytest output. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,24 +22,30 @@ pytest = "6.2.2"
 pep8-naming = "0.11.1"
 
 # Optional dependencies
-pytest-inmanta-extensions = {version = "2020.5.1", extras = ["extension"]}
-asyncpg = {version = "0.21.0", extras = ["extension"]}
-click = {version = "7.1.2", extras = ["extension"]}
-pyformance = {version = "0.4", extras = ["extension"]}
-pytest-env = {version = "0.6.2", extras = ["extension", "pytest"]}
-pytest-postgresql = {version = "2.5.3", extras = ["extension"]}
-psycopg2 = {version = "2.8.6", extras = ["extension"]}
-tornado = {version = "6.1", extras = ["extension"]}
-pytest-inmanta = {version = "1.4.0", extras = ["module"]}
-tox = {version = "3.21.3", extras = ["module"]}
-tox-venv = {version = "0.4.0", extras = ["module"]}
-pytest-asyncio = {version = "0.14.0", extras = ["async"]}
-pytest-timeout = {version = "1.4.2", extras = ["async"]}
-pytest-cover = {version = "3.0.0", extras = ["pytest"]}
-pytest-randomly = {version = "3.5.0", extras = ["pytest"]}
-pytest-xdist = {version = "2.2.0", extras = ["pytest"]}
-pytest-sugar = {version = "0.9.4", extras = ["pytest"]}
-pytest-instafail = {version = "0.4.2", extras = ["pytest"]}
+pytest-inmanta-extensions = {version = "2020.5.1", optional=true}
+asyncpg = {version = "0.21.0", optional=true}
+click = {version = "7.1.2", optional=true}
+pyformance = {version = "0.4", optional=true}
+pytest-env = {version = "0.6.2", optional=true}
+pytest-postgresql = {version = "2.5.3", optional=true}
+psycopg2 = {version = "2.8.6", optional=true}
+tornado = {version = "6.1", optional=true}
+pytest-inmanta = {version = "1.4.0", optional=true}
+tox = {version = "3.21.3", optional=true}
+tox-venv = {version = "0.4.0", optional=true}
+pytest-asyncio = {version = "0.14.0", optional=true}
+pytest-timeout = {version = "1.4.2", optional=true}
+pytest-cover = {version = "3.0.0", optional=true}
+pytest-randomly = {version = "3.5.0", optional=true}
+pytest-xdist = {version = "2.2.0", optional=true}
+pytest-sugar = {version = "0.9.4", optional=true}
+pytest-instafail = {version = "0.4.2", optional=true}
+
+[tool.poetry.extras]
+module = ["pytest-inmanta"]
+extension = ["pytest-inmanta-extensions", "asyncpg", "click", "pyformance", "pytest-env", "pytest-postgresql", "psycopg2", "tornado", "tox", "tox-venv", "tornado"]
+async = ["pytest-asyncio", "pytest-timeout"]
+pytest = ["pytest-env", "pytest-cover", "pytest-randomly", "pytest-xdist", "pytest-sugar", "pytest-instafail", "pytest-sugar", "pytest-instafail"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,27 +19,27 @@ isort = "5.7.0"
 lxml = "4.6.2"
 mypy = "0.800"
 pytest = "6.2.2"
-pep8-naming = "^0.11.1"
+pep8-naming = "0.11.1"
 
 # Optional dependencies
-pytest-inmanta-extensions = {version = "^2020.5.1", extras = ["extension"]}
-asyncpg = {version = "^0.21.0", extras = ["extension"]}
-click = {version = "^7.1.2", extras = ["extension"]}
-pyformance = {version = "^0.4", extras = ["extension"]}
-pytest-env = {version = "^0.6.2", extras = ["extension", "pytest"]}
-pytest-postgresql = {version = "^2.5.3", extras = ["extension"]}
-psycopg2 = {version = "^2.8.6", extras = ["extension"]}
-tornado = {version = "^6.1", extras = ["extension"]}
-pytest-inmanta = {version = "^1.4.0", extras = ["module"]}
-tox = {version = "^3.21.3", extras = ["module"]}
-tox-venv = {version = "^0.4.0", extras = ["module"]}
-pytest-asyncio = {version = "^0.14.0", extras = ["async"]}
-pytest-timeout = {version = "^1.4.2", extras = ["async"]}
-pytest-cover = {version = "^3.0.0", extras = ["pytest"]}
-pytest-randomly = {version = "^3.5.0", extras = ["pytest"]}
-pytest-xdist = {version = "^2.2.0", extras = ["pytest"]}
-pytest-sugar = {version = "^0.9.4", extras = ["pytest"]}
-pytest-instafail = {version = "^0.4.2", extras = ["pytest"]}
+pytest-inmanta-extensions = {version = "2020.5.1", extras = ["extension"]}
+asyncpg = {version = "0.21.0", extras = ["extension"]}
+click = {version = "7.1.2", extras = ["extension"]}
+pyformance = {version = "0.4", extras = ["extension"]}
+pytest-env = {version = "0.6.2", extras = ["extension", "pytest"]}
+pytest-postgresql = {version = "2.5.3", extras = ["extension"]}
+psycopg2 = {version = "2.8.6", extras = ["extension"]}
+tornado = {version = "6.1", extras = ["extension"]}
+pytest-inmanta = {version = "1.4.0", extras = ["module"]}
+tox = {version = "3.21.3", extras = ["module"]}
+tox-venv = {version = "0.4.0", extras = ["module"]}
+pytest-asyncio = {version = "0.14.0", extras = ["async"]}
+pytest-timeout = {version = "1.4.2", extras = ["async"]}
+pytest-cover = {version = "3.0.0", extras = ["pytest"]}
+pytest-randomly = {version = "3.5.0", extras = ["pytest"]}
+pytest-xdist = {version = "2.2.0", extras = ["pytest"]}
+pytest-sugar = {version = "0.9.4", extras = ["pytest"]}
+pytest-instafail = {version = "0.4.2", extras = ["pytest"]}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,18 +19,27 @@ isort = "5.7.0"
 lxml = "4.6.2"
 mypy = "0.800"
 pytest = "6.2.2"
+pep8-naming = "^0.11.1"
 
 # Optional dependencies
-pytest-asyncio = { version = "0.14.0", optional = true }
-pytest-inmanta = { version = "1.4.0", optional = true }
-pytest-timeout = { version = "1.4.2", optional = true }
-tox = { version = "3.21.3", optional = true }
-tox-venv = { version = "0.4.0", optional = true }
-
-[tool.poetry.extras]
-async = ["pytest-asyncio", "pytest-timeout"]
-extension = ["tox", "tox-venv"]
-module = ["pytest-inmanta"]
+pytest-inmanta-extensions = {version = "^2020.5.1", extras = ["extension"]}
+asyncpg = {version = "^0.21.0", extras = ["extension"]}
+click = {version = "^7.1.2", extras = ["extension"]}
+pyformance = {version = "^0.4", extras = ["extension"]}
+pytest-env = {version = "^0.6.2", extras = ["extension", "pytest"]}
+pytest-postgresql = {version = "^2.5.3", extras = ["extension"]}
+psycopg2 = {version = "^2.8.6", extras = ["extension"]}
+tornado = {version = "^6.1", extras = ["extension"]}
+pytest-inmanta = {version = "^1.4.0", extras = ["module"]}
+tox = {version = "^3.21.3", extras = ["module"]}
+tox-venv = {version = "^0.4.0", extras = ["module"]}
+pytest-asyncio = {version = "^0.14.0", extras = ["async"]}
+pytest-timeout = {version = "^1.4.2", extras = ["async"]}
+pytest-cover = {version = "^3.0.0", extras = ["pytest"]}
+pytest-randomly = {version = "^3.5.0", extras = ["pytest"]}
+pytest-xdist = {version = "^2.2.0", extras = ["pytest"]}
+pytest-sugar = {version = "^0.9.4", extras = ["pytest"]}
+pytest-instafail = {version = "^0.4.2", extras = ["pytest"]}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This PR does a number of things:

- Reorganizes all extras such like they added with the cli tool
- Add all deps of pytest-inmanta-extensions to the direct deps so that these versions are pinned.
- Add pep8-naming to the default set of deps because this is listed for some extensions and some not. But it is part of our default set. This might cause issues on extensions and module that we will need to fix.
- Added an extra catagory with pytest plugins that are present in core, license, lsm, ... (but not all of them in ui for example).

Open question:

The pytest plugins are now in a new extras group. Do I add them to the default list?