### PR TITLE
 Remove version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ pytest = "6.2.2"
 pep8-naming = "0.11.1"
 
 # Optional dependencies
-pytest-inmanta-extensions = {optional=true}
+pytest-inmanta-extensions = {version = "*", optional=true}
 pytest-env = {version = "0.6.2", optional=true}
 pytest-postgresql = {version = "2.6.0", optional=true}
 psycopg2 = {version = "2.8.6", optional=true}
-pytest-inmanta = {optional=true}
+pytest-inmanta = {version="*", optional=true}
 tox = {version = "3.22.0", optional=true}
 pytest-asyncio = {version = "0.14.0", optional=true}
 pytest-timeout = {version = "1.4.2", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ pytest = "6.2.2"
 pep8-naming = "0.11.1"
 
 # Optional dependencies
-pytest-inmanta-extensions = {version = "2020.5.1", optional=true}
+pytest-inmanta-extensions = {optional=true}
 pytest-env = {version = "0.6.2", optional=true}
 pytest-postgresql = {version = "2.6.0", optional=true}
 psycopg2 = {version = "2.8.6", optional=true}
-pytest-inmanta = {version = "1.4.0", optional=true}
+pytest-inmanta = {optional=true}
 tox = {version = "3.22.0", optional=true}
 pytest-asyncio = {version = "0.14.0", optional=true}
 pytest-timeout = {version = "1.4.2", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pytest-inmanta-extensions = {version = "*", optional=true}
 pytest-env = {version = "0.6.2", optional=true}
 pytest-postgresql = {version = "2.6.0", optional=true}
 psycopg2 = {version = "2.8.6", optional=true}
-pytest-inmanta = {version="*", optional=true}
+pytest-inmanta = {version = "*", optional=true}
 tox = {version = "3.22.0", optional=true}
 pytest-asyncio = {version = "0.14.0", optional=true}
 pytest-timeout = {version = "1.4.2", optional=true}


### PR DESCRIPTION
Remove version constraint on the `pytest-inmanta` and `pytest-inmanta-extensions` package as such that it's possible to install dev releases when required.