### PR TITLE
Add core feature to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ tornado = {version = "^6.1", optional=true}
 
 [tool.poetry.extras]
 module = ["pytest-inmanta"]
+core = ["asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornado"]
 extension = ["pytest-inmanta-extensions", "asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornado"]
 async = ["pytest-asyncio", "pytest-timeout"]
 pytest = ["pytest-env", "pytest-cover", "pytest-randomly", "pytest-xdist", "pytest-sugar", "pytest-instafail", "pytest-sugar", "pytest-instafail"]


### PR DESCRIPTION
Add support to install the dev dependencies for `inmanta-core` without installing the `pytest-inmanta-extensions` package which is already present in the `inmanta-core` repository.