### PR TITLE
Add recommonmark dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ core = ["asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornad
 extension = ["pytest-inmanta-extensions", "asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornado"]
 async = ["pytest-asyncio", "pytest-timeout"]
 pytest = ["pytest-env", "pytest-cover", "pytest-randomly", "pytest-xdist", "pytest-sugar", "pytest-instafail", "pytest-sugar", "pytest-instafail"]
-sphinx = ["inmanta-sphinx", "sphinx-argparse", "sphinx-autodoc-annotation", "sphinx-rtd-theme", "sphinx-tabs", "sphinx", "sphinxcontrib-serializinghtml", "sphinxcontrib-redoc", "sphinx-click"]
+sphinx = ["inmanta-sphinx", "sphinx-argparse", "sphinx-autodoc-annotation", "sphinx-rtd-theme", "sphinx-tabs", "sphinx", "sphinxcontrib-serializinghtml", "sphinxcontrib-redoc", "sphinx-click", "recommonmark"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Sphinx = {version = "3.5.4", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.4", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}
 sphinx-click = {version = "2.7.1", optional = true}
+recommonmark = {version = "0.7.1", optional = true}
 
 # These are test and direct dependencies of certains extensions. We use carret version
 # constraints so that updates are possible.


### PR DESCRIPTION
The `recommonmark` dependency to allow rendering markdown files in the sphinx documentation. This is required by inmanta/irt#417