### PR TITLE
Migrate from psycopg2 to psycopg>=3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pep8-naming = "0.12.1"
 pytest-inmanta-extensions = {version = "*", optional=true}
 pytest-env = {version = "0.6.2", optional=true}
 pytest-postgresql = {version = "4.1.0", optional=true}
-psycopg2 = {version = "2.9.3", optional=true}
+psycopg = {version = "3.0.8", optional=true}
 pytest-inmanta = {version = "*", optional=true}
 tox = {version = "3.24.5", optional=true}
 pytest-asyncio = {version = "0.17.2", optional=true}


### PR DESCRIPTION
`pytest-postgresql>=4` requires `psycopg>=3` instead of `psycopg2`. This PR implements that change.