### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ inmanta-sphinx = {version = "1.5.0", optional = true}
 sphinx-argparse = {version = "0.3.1", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
 sphinx-rtd-theme = {version = "1.0.0", optional = true}
-sphinx-tabs = {version = "3.4.0", optional = true}
+sphinx-tabs = {version = "3.4.1", optional = true}
 Sphinx = {version = "5.0.2", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}


### PR DESCRIPTION
Add jinja 4 support to sphinx-tabs

should fix https://github.com/inmanta/inmanta-core/pull/4512

for some reason depdenabot doesn't want to make the bump 

# Part 2

blocked by https://github.com/readthedocs/sphinx_rtd_theme/issues/1302

```
  Because sphinx-tabs (3.4.1) depends on docutils (>=0.18.0,<0.19.0)
   and sphinx-rtd-theme (1.0.0) depends on docutils (<0.18), sphinx-tabs (3.4.1) is incompatible with sphinx-rtd-theme (1.0.0).
  So, because inmanta-dev-dependencies depends on both sphinx-rtd-theme (1.0.0) and sphinx-tabs (3.4.1), version solving failed.
```