### PR TITLE
Fix dependency conflict between sphinx tabs and sphinx rtd

### DIFF
--- a/.ci/Jenkinsfile-integration-test
+++ b/.ci/Jenkinsfile-integration-test
@@ -49,7 +49,7 @@ pipeline {
             steps {
                 dir(env.REPO_NAME) {
                     script {
-                        sh '${WORKSPACE}/env/bin/poetry install --extras "async extension module pytest sphinx"'
+                        sh '${WORKSPACE}/env/bin/poetry install --extras "async extension module pytest sphinx core"'
                     }
                 }
             }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@ updates:
    - dependency-name: "flake8"
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
-    - dependency-name: "sphinx tabs"
+   - dependency-name: "sphinx tabs"
       versions: [">=3.3.1"]
       # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
-    - dependency-name: "Sphinx"
+   - dependency-name: "Sphinx"
       versions: [">=4.5.0"]
       # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
    - dependency-name: "sphinx tabs"
-      versions: [">=3.3.1"]
-      # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
+     versions: [">=3.3.1"]
+     # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
    - dependency-name: "Sphinx"
-      versions: [">=4.5.0"]
-      # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      
+     versions: [">=4.5.0"]
+     # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,8 @@ updates:
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
   - dependency-name: "sphinx tabs"
-    versions: [">=3.4.1"]
-      # sphinx tabs >=3.4.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
+    versions: [">=3.3.1"]
+      # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
+- dependency-name: "Sphinx"
+    versions: [">=4.5.0"]
+      # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,19 @@
 version: 2
 updates:
-    # poetry is part of the pip ecosystem
-    - package-ecosystem: pip
-      directory: "/"
-      schedule:
-          interval: daily
-      open-pull-requests-limit: 10
-      ignore:
-          - dependency-name: "asyncpg"
-          - dependency-name: "flake8"
-            versions: [">=4.0.0"]
-            # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
-          - dependency-name: "sphinx tabs"
-            versions: [">=3.4.0"]
-            # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
-          - dependency-name: "Sphinx"
-            versions: [">=4.6.0"]
-            # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)
+# poetry is part of the pip ecosystem
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+   - dependency-name: "asyncpg"
+   - dependency-name: "flake8"
+     versions: [">=4.0.0"]
+     # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
+   - dependency-name: "sphinx tabs"
+     versions: [">=3.4.0"]
+     # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
+   - dependency-name: "Sphinx"
+     versions: [">=4.6.0"]
+     # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
    - dependency-name: "flake8"
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
+  - dependency-name: "sphinx tabs"
+    versions: [">=3.4.1"]
+      # sphinx tabs >=3.4.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@ updates:
    - dependency-name: "flake8"
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
-  - dependency-name: "sphinx tabs"
-    versions: [">=3.3.1"]
+    - dependency-name: "sphinx tabs"
+      versions: [">=3.3.1"]
       # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
-- dependency-name: "Sphinx"
-    versions: [">=4.5.0"]
+    - dependency-name: "Sphinx"
+      versions: [">=4.5.0"]
       # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,19 @@
 version: 2
 updates:
-# poetry is part of the pip ecosystem
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  ignore:
-   - dependency-name: "asyncpg"
-   - dependency-name: "flake8"
-     versions: [">=4.0.0"]
-     # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
-   - dependency-name: "sphinx tabs"
-     versions: [">=3.3.1"]
-     # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
-   - dependency-name: "Sphinx"
-     versions: [">=4.5.0"]
-     # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)      
+    # poetry is part of the pip ecosystem
+    - package-ecosystem: pip
+      directory: "/"
+      schedule:
+          interval: daily
+      open-pull-requests-limit: 10
+      ignore:
+          - dependency-name: "asyncpg"
+          - dependency-name: "flake8"
+            versions: [">=4.0.0"]
+            # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
+          - dependency-name: "sphinx tabs"
+            versions: [">=3.4.0"]
+            # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
+          - dependency-name: "Sphinx"
+            versions: [">=4.6.0"]
+            # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ sphinx-argparse = {version = "0.3.1", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
 sphinx-rtd-theme = {version = "1.0.0", optional = true}
 sphinx-tabs = {version = "3.3.1", optional = true}
-Sphinx = {version = "5.0.2", optional = true}
+Sphinx = {version = "4.5.0", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}
 sphinx-click = {version = "4.3.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ inmanta-sphinx = {version = "1.5.0", optional = true}
 sphinx-argparse = {version = "0.3.1", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
 sphinx-rtd-theme = {version = "1.0.0", optional = true}
-sphinx-tabs = {version = "3.4.0", optional = true}
+sphinx-tabs = {version = "3.3.1", optional = true}
 Sphinx = {version = "5.0.2", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}


### PR DESCRIPTION
- sphinx tabs >=3.4.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18.
- sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)
This commit sets the version of sphinx tabs back to 3.3.1, Sphinx back to 4.5.0 and prevents depandabot from bumping those.

