### PR TITLE
Update sphinx deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,3 @@ updates:
    - dependency-name: "flake8"
      versions: [">=4.0.0"]
      # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
-   - dependency-name: "sphinx-tabs"
-     versions: [">=3.4.0"]
-     # sphinx tabs >=3.3.1 requires docutils > 0.18 and sphinx rtd theme is not compatible with docutils >= 0.18
-   - dependency-name: "Sphinx"
-     versions: [">=4.6.0"]
-     # sphinx-tabs (3.3.1) depends on sphinx (>=2,<5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ pytest-instafail = {version = "0.4.2", optional=true}
 inmanta-sphinx = {version = "1.6.1", optional = true}
 sphinx-argparse = {version = "0.4.0", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
-sphinx-tabs = {version = "3.3.1", optional = true}
-Sphinx = {version = "4.5.0", optional = true}
+sphinx-tabs = {version = "3.4.1", optional = true}
+Sphinx = {version = "5.3.0", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}
 sphinx-click = {version = "4.4.0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,13 @@ pytest-instafail = {version = "0.4.2", optional=true}
 inmanta-sphinx = {version = "1.6.1", optional = true}
 sphinx-argparse = {version = "0.4.0", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
-sphinx-rtd-theme = {version = "1.1.1", optional = true}
 sphinx-tabs = {version = "3.3.1", optional = true}
 Sphinx = {version = "4.5.0", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}
 sphinx-click = {version = "4.4.0", optional = true}
 recommonmark = {version = "0.7.1", optional = true}
+myst_parser = {version = "0.18.1", optional = true}
 
 # These are test and direct dependencies of certain extensions. We use carret version
 # constraints so that updates are possible.
@@ -58,7 +58,10 @@ core = ["asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornad
 extension = ["pytest-inmanta-extensions", "asyncpg", "pytest-env", "pytest-postgresql", "psycopg2", "tox", "tornado"]
 async = ["pytest-asyncio", "pytest-timeout"]
 pytest = ["pytest-env", "pytest-cover", "pytest-randomly", "pytest-xdist", "pytest-sugar", "pytest-instafail", "pytest-sugar", "pytest-instafail"]
-sphinx = ["inmanta-sphinx", "sphinx-argparse", "sphinx-autodoc-annotation", "sphinx-rtd-theme", "sphinx-tabs", "sphinx", "sphinxcontrib-serializinghtml", "sphinxcontrib-redoc", "sphinx-click", "recommonmark"]
+sphinx = [
+    "inmanta-sphinx", "sphinx-argparse", "sphinx-autodoc-annotation", "sphinx-tabs", "sphinx", "sphinxcontrib-serializinghtml",
+    "sphinxcontrib-redoc", "sphinx-click", "recommonmark", "myst_parser"
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
I removed the rtd theme that holds back the other versions. With that gone:

- Remove filter from depbot config
- Update version to latest that works
- Added new markdown plugin as well