### PR TITLE
hold back sphinx and drop outdated dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
-   - dependency-name: "asyncpg"
-   - dependency-name: "flake8"
-     versions: [">=4.0.0"]
-     # flake8 >= 4.0 conflicts with importlib_metadata > 4.3 as per this: PyCQA/flake8#1438
+  - dependency-name: "Sphinx"
+    # conflicts with a dependency of core, tracked in inmanta/infra-tickets#121
+    versions: [">=6"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pytest-instafail = {version = "0.4.2", optional=true}
 inmanta-sphinx = {version = "1.7.0", optional = true}
 sphinx-argparse = {version = "0.4.0", optional = true}
 sphinx-autodoc-annotation = {version = "1.0-1", optional = true}
-Sphinx = {version = "6.1.3", optional = true}
+Sphinx = {version = "5.3.0", optional = true}
 sphinxcontrib-serializinghtml = {version = "1.1.5", optional = true}
 sphinxcontrib-redoc = {version = "1.6.0", optional = true}
 sphinx-click = {version = "4.4.0", optional = true}


### PR DESCRIPTION
- added Sphinx ignore: updated table in inmanta/infra-tickets#121
- dropped asyncpg ignore. This was added back in 2021 (#39) without a comment or an entry in the above-mentioned table. I thought we'd try to bump it and see what happens.
- dropped flake8 ignore: closes #201