### PR TITLE
resumed sphinx dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "Sphinx"
-    # conflicts with a dependency of core, tracked in inmanta/infra-tickets#121
-    versions: [">=6"]


### PR DESCRIPTION
This was held back because the newer versions conflicted with `sphinx-design`. This was fixed by executablebooks/sphinx-design#106 and released in 0.4.1, which is the version currently used by core.