### PR TITLE
Ensure that venvs used by poetry are created in the project directory

### DIFF
--- a/.ci/Jenkinsfile-integration-test
+++ b/.ci/Jenkinsfile-integration-test
@@ -10,6 +10,7 @@ pipeline {
         PIP_INDEX_URL='https://artifacts.internal.inmanta.com/inmanta/dev'
         // No prompts allowed
         PYTHON_KEYRING_BACKEND="keyring.backends.null.Keyring"
+        POETRY_VIRTUALENVS_IN_PROJECT="true"
     }
 
     options {
@@ -55,6 +56,11 @@ pipeline {
                     }
                 }
             }
+        }
+    }
+    post{
+        cleanup{
+            deleteDir()
         }
     }
 }


### PR DESCRIPTION
By default poetry creates venvs in `{cache-dir}/virtualenvs` (See: https://python-poetry.org/docs/configuration/#virtualenvspath), which is a directory outside of the project directory. Venvs in this directory can be reused across builds. This PR ensures that venvs are created in the project directory to make sure that we always start from a clean venv and that we don't suffer from issues related to a broken venv.