### PR TITLE
Move the pytest-asyncio dependency back to v0.21.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   ignore:
   - dependency-name: "pytest-asyncio"
     # https://github.com/pytest-dev/pytest-asyncio/issues/713
-    versions: ["0.23.0","0.23.1", "0.23.2"]
+    versions: ["0.23.0","0.23.1", "0.23.2", "0.32.3"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   ignore:
   - dependency-name: "pytest-asyncio"
     # https://github.com/pytest-dev/pytest-asyncio/issues/713
-    versions: ["0.23.0","0.23.1", "0.23.2", "0.32.3"]
+    versions: ["0.23.0","0.23.1", "0.23.2", "0.23.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ extension = [
     "tornado>=6.1,<7.0"
 ]
 async = [
-    "pytest-asyncio==0.23.3",
+    "pytest-asyncio==0.21.1",
     "pytest-timeout==2.2.0"
 ]
 pytest = [


### PR DESCRIPTION
* Move the pytest-asyncio dependency back to `v0.21.1`.
* Exclude the broken `0.32.3` version from dependabot updates.