### PR TITLE
Downgrade pytest to version 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "pytest-asyncio"
-    # https://github.com/pytest-dev/pytest-asyncio/issues/713
-    versions: ["0.23.0","0.23.1", "0.23.2", "0.23.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "lxml==5.1.0",
     "mypy==1.8.0",
     "pep8-naming==0.13.3",
-    "pytest==8.0.0",
+    "pytest==7.4.4",
     "pyupgrade==3.15.0",
 ]
 


### PR DESCRIPTION
* The pytest-asyncio package is not compatible with `pytest=8`, so this PR downgrades pytest to version 7 again.
* It seems that `pytest-asyncio==0.23.4` is working fine. This PR removes the ignore for older dependabot version bumps.