### PR TITLE
Remove pytest-xdist dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ pytest = [
     "pytest-env==1.1.3",
     "pytest-cover==3.0.0",
     "pytest-randomly==3.15.0",
-    "pytest-xdist==3.6.0",
     "pytest-sugar==1.0.0",
     "pytest-instafail==0.5.0"
 ]


### PR DESCRIPTION
As per [discussion](https://inmanta.slack.com/archives/CKRF0C8R3/p1714384480783459?thread_ts=1714380579.641589&cid=CKRF0C8R3):

- Remove `pytest-xdist` dependency that is no longer used and causes some conflicts.
