### PR TITLE
reverted ignore on new minor pytest version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-    # Migrating to pytest 8 requires the fix https://github.com/inmanta/inmanta-core/commit/b68bfccf1cc02dfb7b5b60b7d44520997949ea8f
-    # to be present in a stable release. This ignore can be removed after the next major release.
-    - dependency-name: "pytest"
-      update-types: ["version-update:semver-major"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "lxml==5.2.2",
     "mypy==1.11.0",
     "pep8-naming==0.14.1",
-    "pytest==7.4.4",
+    "pytest==8.0.1",
     "pyupgrade==3.16.0",
     "mypy-baseline==0.7.1",
 ]


### PR DESCRIPTION
Just reverted the entire PR. Should we pin to a different version now or is this fine?

closes #381 

