### PR TITLE
added flake8-junit-report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "flake8-copyright==0.2.4",
     "flake8-black==0.3.6",
     "flake8-isort==6.1.2",
+    "flake8-junit-report==2.1.0",
     "isort==6.0.1",
     "lxml==5.3.2",
     "mypy==1.15.0",


### PR DESCRIPTION
This used to be installed via the Makefile. I think it makes sense to have this as a dev dependency.